### PR TITLE
support cluster wide operation

### DIFF
--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -31,7 +31,11 @@ spec:
           - percona-xtradb-cluster-operator
           env:
             - name: WATCH_NAMESPACE
-              value: {{ default .Release.Namespace .Values.watchNamespace }}
+            {{- if kindIs "invalid" .Values.watchNamespace }}
+              value: {{ .Release.Namespace }}
+            {{- else }}
+              value:  {{ .Values.watchNamespace }}
+            {{- end }}
             - name: OPERATOR_NAME
               value: {{ default "percona-xtradb-cluster-operator" .Values.operatorName }}
           # livenessProbe:

--- a/charts/pxc-operator/templates/role-binding.yaml
+++ b/charts/pxc-operator/templates/role-binding.yaml
@@ -1,4 +1,8 @@
+{{- if kindIs "invalid" .Values.watchNamespace }}
 kind: RoleBinding
+  {{- else }}
+kind: ClusterRoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
@@ -10,14 +14,14 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: default
-  {{- if .Values.watchNamespace }}
+  {{- if not (kindIs "invalid" .Values.watchNamespace) }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
 roleRef:
-  {{- if .Values.watchNamespace }}
-  kind: ClusterRole
-  {{- else }}
+  {{- if kindIs "invalid" .Values.watchNamespace }}
   kind: Role
+  {{- else }}
+  kind: ClusterRole
   {{- end }}
   name: {{ include "pxc-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/pxc-operator/templates/role.yaml
+++ b/charts/pxc-operator/templates/role.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.watchNamespace }}
-kind: ClusterRole
-{{- else }}
+{{ if kindIs "invalid" .Values.watchNamespace }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/charts/pxc-operator/values.yaml
+++ b/charts/pxc-operator/values.yaml
@@ -11,7 +11,7 @@ image:
 
 # set if you want to specify a namespace to watch
 # defaults to `.Release.namespace` if left blank
-# watchNamespace:
+# watchNamespace: ""
 
 # set if you want to use a different operator name
 # defaults to `percona-xtradb-cluster-operator`


### PR DESCRIPTION
this is basically a copy of https://github.com/paulczar/percona-helm-charts/pull/1, but to the correct upstream repository.

with this change it is possible to watch all namespaces for percona-xtradb-cluster deployments.