### PR TITLE
Move allowUnsafeConfigurations to .spec, add value

### DIFF
--- a/charts/pxc-db/production-values.yaml
+++ b/charts/pxc-db/production-values.yaml
@@ -14,6 +14,7 @@ nameOverride: "production"
 fullnameOverride: "production"
 
 pause: false
+allowUnsafeConfigurations: false
 
 pxc:
   size: 3

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -27,13 +27,13 @@ spec:
   sslInternalSecretName: {{ include "pxc-database.fullname" . }}-ssl-internal
   {{- end }}
   {{- end }}
+  {{- if or .Values.allowUnsafeConfigurations .Values.pxc.disableTLS }}
+  allowUnsafeConfigurations: true
+  {{- end }}
   pause: {{ .Values.pause }}
   {{- $pxc := .Values.pxc }}
   pxc:
     size: {{ $pxc.size }}
-    {{- if .Values.pxc.disableTLS }}
-    allowUnsafeConfigurations: false
-    {{- end }}
     image: "{{ $pxc.image.repository }}:{{ $pxc.image.tag }}"
     readinessDelaySec: {{ $pxc.readinessDelaySec }}
     livenessDelaySec: {{ $pxc.livenessDelaySec }}

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -13,6 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 pause: false
+allowUnsafeConfigurations: false
 
 pxc:
   size: 3


### PR DESCRIPTION
`allowUnsafeConfigurations` field was on the wrong level (`spec.pxc`), it should go beneath `spec`.
Looking through the operator code I also think you intended to put it to `true` when TLS is disabled, I don't see how this otherwise makes sense.

For local development it is quiet useful to start the PXC with the size of **1** (even though it's a *cluster*), so I added `allowUnsafeConfigurations` to the values file as well.