### PR TITLE
Add example for changing endpoint url for s3

### DIFF
--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -186,6 +186,7 @@ backup:
     #     bucket: S3-BACKUP-BUCKET-NAME-HERE
     #     credentialsSecret: my-cluster-name-backup-s3
     #     region: us-west-2
+    #     endpointUrl: sfo2.digitaloceanspaces.com
 
   schedule:
     - name: "daily-backup"

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -186,7 +186,7 @@ backup:
     #     bucket: S3-BACKUP-BUCKET-NAME-HERE
     #     credentialsSecret: my-cluster-name-backup-s3
     #     region: us-west-2
-    #     endpointUrl: sfo2.digitaloceanspaces.com
+    #     endpointUrl: https://sfo2.digitaloceanspaces.com
 
   schedule:
     - name: "daily-backup"


### PR DESCRIPTION
s3 interface can be used in multiple cloud providers. So endpointUrl could be useful for anyone using non standard s3 interface of aws. eg: DigitalOcean